### PR TITLE
Network discovery cap

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -131,6 +131,7 @@ uint8_t *script_buf = 0;
 size_t script_buf_size = 0;
 uint8_t script_buf_flash = false;
 
+unti8_t *network_discovery_cap = 20;
 
 /**
  * command interface
@@ -228,24 +229,19 @@ void tessel_cmd_process (uint8_t cmd, uint8_t* buf, unsigned size)
 		uint8_t results[64];
 		int res = 0;
 		int first = 1;
-		while (true) {
-			// TODO: this should pass data back as a message in structured form
-			// (which requires generating a JSON array)
-			res = wlan_ioctl_get_scan_results(0, results);
-			char* networkcountptr = (char*) &results[0];
-			uint32_t networkcount = *((uint32_t*) networkcountptr);
-			if (first) {
-				if (networkcount == 0) {
-					tm_logf('V', "There are no visible networks yet.");
-				} else {
-					tm_logf('V', "Currently visible networks (%ld):", networkcount);
-					first = 0;
-				}
-			}
-			if (res != 0 || networkcount == 0) {
-				break;
-			}
-
+		int current_network = 0;
+		
+		res = wlan_ioctl_get_scan_results(0, results);
+		char* networkcountptr = (char*) &results[0];
+		uint32_t networkcount = *((uint32_t*) networkcountptr);
+			
+		if (networkcount >0 && first) {
+			tm_logf('V', "Currently visible networks (%ld):", networkcount);
+		} else {
+			tm_logf('V', "No networks are currently visible");
+		}
+		
+		while ((res == !0 || networkcount > 0 ) && (current_network <= network_discovery_cap)){
 			int rssi = 0;
 			if (results[8] & 0x1) {
 				rssi = results[8] >> 1;

--- a/src/main.c
+++ b/src/main.c
@@ -235,13 +235,13 @@ void tessel_cmd_process (uint8_t cmd, uint8_t* buf, unsigned size)
 		char* networkcountptr = (char*) &results[0];
 		uint32_t networkcount = *((uint32_t*) networkcountptr);
 			
-		if (networkcount >0 && first) {
+		if (networkcount > 0 && first) {
 			tm_logf('V', "Currently visible networks (%ld):", networkcount);
 		} else {
 			tm_logf('V', "No networks are currently visible");
 		}
 		
-		while ((res == !0 || networkcount > 0 ) && (current_network <= network_discovery_cap)){
+		while ((res == !0 || networkcount > 0 ) && (current_network <= network_discovery_cap) && (current_network <= networkcount)){
 			int rssi = 0;
 			if (results[8] & 0x1) {
 				rssi = results[8] >> 1;
@@ -251,6 +251,7 @@ void tessel_cmd_process (uint8_t cmd, uint8_t* buf, unsigned size)
 			unsigned char namebuf[33] = { 0 };
 			memcpy(namebuf, nameptr, 32);
 			tm_logf('V', "\t%s (%i/127)", namebuf, rssi);
+			current_network++;
 		}
 
 		if (hw_net_is_connected()) {


### PR DESCRIPTION
This should fix https://github.com/tessel/firmware/issues/46 and allow only the first 20 networks discovered to be iterated over. It's a fix but it's not ideal really, perhaps we should also add an ability to supply cap value on the command line.