### PR TITLE
Fix problematic readPulse test

### DIFF
--- a/test/test_read_pulse.js
+++ b/test/test_read_pulse.js
@@ -11,7 +11,7 @@ var neopixels = new Neopixels();
 var numNeopixels = 24;
 
 // Percent diff of what's read and what's expected due to setTimeout inaccuracy
-var marginOfError = 0.04;
+var marginOfError = 0.25;
 
 // make sure type input checks work
 test('testing input validation', function (t) {


### PR DESCRIPTION
JS can't be expected to be real-time, and this is not a performance test. These tests have been problematic in the past, and are now constantly failing on master with no code change.